### PR TITLE
Adicionado API em phoenix para calcular as quatro operações básicas de uma calculadora

### DIFF
--- a/calc_phx/lib/calc_phx/api/api.ex
+++ b/calc_phx/lib/calc_phx/api/api.ex
@@ -1,0 +1,104 @@
+defmodule CalcPhx.Api do
+  @moduledoc """
+  The Api context.
+  """
+
+  import Ecto.Query, warn: false
+  alias CalcPhx.Repo
+
+  alias CalcPhx.Api.Calculator
+
+  @doc """
+  Returns the list of calculators.
+
+  ## Examples
+
+      iex> list_calculators()
+      [%Calculator{}, ...]
+
+  """
+  def list_calculators do
+    Repo.all(Calculator)
+  end
+
+  @doc """
+  Gets a single calculator.
+
+  Raises `Ecto.NoResultsError` if the Calculator does not exist.
+
+  ## Examples
+
+      iex> get_calculator!(123)
+      %Calculator{}
+
+      iex> get_calculator!(456)
+      ** (Ecto.NoResultsError)
+
+  """
+  def get_calculator!(id), do: Repo.get!(Calculator, id)
+
+  @doc """
+  Creates a calculator.
+
+  ## Examples
+
+      iex> create_calculator(%{field: value})
+      {:ok, %Calculator{}}
+
+      iex> create_calculator(%{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def create_calculator(attrs \\ %{}) do
+    %Calculator{}
+    |> Calculator.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  @doc """
+  Updates a calculator.
+
+  ## Examples
+
+      iex> update_calculator(calculator, %{field: new_value})
+      {:ok, %Calculator{}}
+
+      iex> update_calculator(calculator, %{field: bad_value})
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def update_calculator(%Calculator{} = calculator, attrs) do
+    calculator
+    |> Calculator.changeset(attrs)
+    |> Repo.update()
+  end
+
+  @doc """
+  Deletes a Calculator.
+
+  ## Examples
+
+      iex> delete_calculator(calculator)
+      {:ok, %Calculator{}}
+
+      iex> delete_calculator(calculator)
+      {:error, %Ecto.Changeset{}}
+
+  """
+  def delete_calculator(%Calculator{} = calculator) do
+    Repo.delete(calculator)
+  end
+
+  @doc """
+  Returns an `%Ecto.Changeset{}` for tracking calculator changes.
+
+  ## Examples
+
+      iex> change_calculator(calculator)
+      %Ecto.Changeset{source: %Calculator{}}
+
+  """
+  def change_calculator(%Calculator{} = calculator) do
+    Calculator.changeset(calculator, %{})
+  end
+end

--- a/calc_phx/lib/calc_phx/api/calculator.ex
+++ b/calc_phx/lib/calc_phx/api/calculator.ex
@@ -1,0 +1,19 @@
+defmodule CalcPhx.Api.Calculator do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias CalcPhx.Api.Calculator
+
+
+  schema "calculators" do
+    field :name, :string
+
+    timestamps()
+  end
+
+  @doc false
+  def changeset(%Calculator{} = calculator, attrs) do
+    calculator
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+  end
+end

--- a/calc_phx/lib/calc_phx_web/controllers/calculator_controller.ex
+++ b/calc_phx/lib/calc_phx_web/controllers/calculator_controller.ex
@@ -1,0 +1,44 @@
+defmodule CalcPhxWeb.CalculatorController do
+  use CalcPhxWeb, :controller
+  require Logger
+
+  alias CalcPhx.Api
+  alias CalcPhx.Api.Calculator
+
+  action_fallback CalcPhxWeb.FallbackController
+
+  def sum(conn, %{"num1" => num1, "num2" => num2}) do
+    a = Decimal.new(num1)
+    b = Decimal.new(num2)
+    total = Decimal.add(a, b)
+    
+    render(conn, "sum.json", total: total)
+  end
+
+  def subtract(conn, %{"num1" => num1, "num2" => num2}) do
+    a = Decimal.new(num1)
+    b = Decimal.new(num2)
+    total = Decimal.sub(a, b)
+    
+    render(conn, "subtract.json", total: total)
+  end
+
+  def multiply(conn, %{"num1" => num1, "num2" => num2}) do
+    a = Decimal.new(num1)
+    b = Decimal.new(num2)
+    total = Decimal.mult(a, b)
+    
+    render(conn, "multiply.json", total: total)
+  end
+
+  def divide(conn, %{"dividend" => dividend, "divisor" => divisor}) do
+    a = Decimal.new(dividend)
+    b = Decimal.new(divisor)
+    total = Decimal.div(a, b)
+
+    # aqui ou no controller precisa colocar um validador de erro para 
+    # não poder haver divisão por 0
+    
+    render(conn, "divide.json", total: total)
+  end
+end

--- a/calc_phx/lib/calc_phx_web/controllers/fallback_controller.ex
+++ b/calc_phx/lib/calc_phx_web/controllers/fallback_controller.ex
@@ -1,0 +1,20 @@
+defmodule CalcPhxWeb.FallbackController do
+  @moduledoc """
+  Translates controller action results into valid `Plug.Conn` responses.
+
+  See `Phoenix.Controller.action_fallback/1` for more details.
+  """
+  use CalcPhxWeb, :controller
+
+  def call(conn, {:error, %Ecto.Changeset{} = changeset}) do
+    conn
+    |> put_status(:unprocessable_entity)
+    |> render(CalcPhxWeb.ChangesetView, "error.json", changeset: changeset)
+  end
+
+  def call(conn, {:error, :not_found}) do
+    conn
+    |> put_status(:not_found)
+    |> render(CalcPhxWeb.ErrorView, :"404")
+  end
+end

--- a/calc_phx/lib/calc_phx_web/router.ex
+++ b/calc_phx/lib/calc_phx_web/router.ex
@@ -1,26 +1,16 @@
 defmodule CalcPhxWeb.Router do
   use CalcPhxWeb, :router
 
-  pipeline :browser do
-    plug :accepts, ["html"]
-    plug :fetch_session
-    plug :fetch_flash
-    plug :protect_from_forgery
-    plug :put_secure_browser_headers
-  end
-
   pipeline :api do
     plug :accepts, ["json"]
   end
 
-  scope "/", CalcPhxWeb do
-    pipe_through :browser # Use the default browser stack
+  scope "/api/v1", CalcPhxWeb do
+    pipe_through :api
 
-    get "/", PageController, :index
+    get "/sum/:num1/:num2",           CalculatorController, :sum
+    get "/subtract/:num1/:num2",     CalculatorController, :subtract
+    get "/divide/:dividend/:divisor", CalculatorController, :divide
+    get "/multiply/:num1/:num2",      CalculatorController, :multiply
   end
-
-  # Other scopes may use custom stacks.
-  # scope "/api", CalcPhxWeb do
-  #   pipe_through :api
-  # end
 end

--- a/calc_phx/lib/calc_phx_web/views/calculator_view.ex
+++ b/calc_phx/lib/calc_phx_web/views/calculator_view.ex
@@ -1,0 +1,21 @@
+defmodule CalcPhxWeb.CalculatorView do
+  use CalcPhxWeb, :view
+  alias CalcPhxWeb.CalculatorView
+
+  def render("sum.json", %{total: total}) do
+    %{data: total}
+  end
+
+  def render("subtract.json", %{total: total}) do
+    %{data: total}
+  end
+  
+  def render("multiply.json", %{total: total}) do
+    %{data: total}
+  end
+
+  def render("divide.json", %{total: total}) do
+    %{data: total}
+  end
+
+end

--- a/calc_phx/lib/calc_phx_web/views/changeset_view.ex
+++ b/calc_phx/lib/calc_phx_web/views/changeset_view.ex
@@ -1,0 +1,19 @@
+defmodule CalcPhxWeb.ChangesetView do
+  use CalcPhxWeb, :view
+
+  @doc """
+  Traverses and translates changeset errors.
+
+  See `Ecto.Changeset.traverse_errors/2` and
+  `CalcPhxWeb.ErrorHelpers.translate_error/1` for more details.
+  """
+  def translate_errors(changeset) do
+    Ecto.Changeset.traverse_errors(changeset, &translate_error/1)
+  end
+
+  def render("error.json", %{changeset: changeset}) do
+    # When encoded, the changeset returns its errors
+    # as a JSON object. So we just pass it forward.
+    %{errors: translate_errors(changeset)}
+  end
+end

--- a/calc_phx/test/calc_phx/api/api_test.exs
+++ b/calc_phx/test/calc_phx/api/api_test.exs
@@ -1,0 +1,65 @@
+defmodule CalcPhx.ApiTest do
+  use CalcPhx.DataCase
+
+  alias CalcPhx.Api
+
+  describe "calculators" do
+    alias CalcPhx.Api.Calculator
+
+    @valid_attrs %{name: "some name"}
+    @update_attrs %{name: "some updated name"}
+    @invalid_attrs %{name: nil}
+
+    def calculator_fixture(attrs \\ %{}) do
+      {:ok, calculator} =
+        attrs
+        |> Enum.into(@valid_attrs)
+        |> Api.create_calculator()
+
+      calculator
+    end
+
+    test "list_calculators/0 returns all calculators" do
+      calculator = calculator_fixture()
+      assert Api.list_calculators() == [calculator]
+    end
+
+    test "get_calculator!/1 returns the calculator with given id" do
+      calculator = calculator_fixture()
+      assert Api.get_calculator!(calculator.id) == calculator
+    end
+
+    test "create_calculator/1 with valid data creates a calculator" do
+      assert {:ok, %Calculator{} = calculator} = Api.create_calculator(@valid_attrs)
+      assert calculator.name == "some name"
+    end
+
+    test "create_calculator/1 with invalid data returns error changeset" do
+      assert {:error, %Ecto.Changeset{}} = Api.create_calculator(@invalid_attrs)
+    end
+
+    test "update_calculator/2 with valid data updates the calculator" do
+      calculator = calculator_fixture()
+      assert {:ok, calculator} = Api.update_calculator(calculator, @update_attrs)
+      assert %Calculator{} = calculator
+      assert calculator.name == "some updated name"
+    end
+
+    test "update_calculator/2 with invalid data returns error changeset" do
+      calculator = calculator_fixture()
+      assert {:error, %Ecto.Changeset{}} = Api.update_calculator(calculator, @invalid_attrs)
+      assert calculator == Api.get_calculator!(calculator.id)
+    end
+
+    test "delete_calculator/1 deletes the calculator" do
+      calculator = calculator_fixture()
+      assert {:ok, %Calculator{}} = Api.delete_calculator(calculator)
+      assert_raise Ecto.NoResultsError, fn -> Api.get_calculator!(calculator.id) end
+    end
+
+    test "change_calculator/1 returns a calculator changeset" do
+      calculator = calculator_fixture()
+      assert %Ecto.Changeset{} = Api.change_calculator(calculator)
+    end
+  end
+end

--- a/calc_phx/test/calc_phx_web/controllers/calculator_controller_test.exs
+++ b/calc_phx/test/calc_phx_web/controllers/calculator_controller_test.exs
@@ -1,0 +1,79 @@
+defmodule CalcPhxWeb.CalculatorControllerTest do
+  use CalcPhxWeb.ConnCase
+
+  alias CalcPhx.Api
+  alias CalcPhx.Api.Calculator
+
+  @create_attrs %{name: "some name"}
+  @update_attrs %{name: "some updated name"}
+  @invalid_attrs %{name: nil}
+
+  def fixture(:calculator) do
+    {:ok, calculator} = Api.create_calculator(@create_attrs)
+    calculator
+  end
+
+  setup %{conn: conn} do
+    {:ok, conn: put_req_header(conn, "accept", "application/json")}
+  end
+
+  describe "index" do
+    test "lists all calculators", %{conn: conn} do
+      conn = get conn, calculator_path(conn, :index)
+      assert json_response(conn, 200)["data"] == []
+    end
+  end
+
+  describe "create calculator" do
+    test "renders calculator when data is valid", %{conn: conn} do
+      conn = post conn, calculator_path(conn, :create), calculator: @create_attrs
+      assert %{"id" => id} = json_response(conn, 201)["data"]
+
+      conn = get conn, calculator_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] == %{
+        "id" => id,
+        "name" => "some name"}
+    end
+
+    test "renders errors when data is invalid", %{conn: conn} do
+      conn = post conn, calculator_path(conn, :create), calculator: @invalid_attrs
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "update calculator" do
+    setup [:create_calculator]
+
+    test "renders calculator when data is valid", %{conn: conn, calculator: %Calculator{id: id} = calculator} do
+      conn = put conn, calculator_path(conn, :update, calculator), calculator: @update_attrs
+      assert %{"id" => ^id} = json_response(conn, 200)["data"]
+
+      conn = get conn, calculator_path(conn, :show, id)
+      assert json_response(conn, 200)["data"] == %{
+        "id" => id,
+        "name" => "some updated name"}
+    end
+
+    test "renders errors when data is invalid", %{conn: conn, calculator: calculator} do
+      conn = put conn, calculator_path(conn, :update, calculator), calculator: @invalid_attrs
+      assert json_response(conn, 422)["errors"] != %{}
+    end
+  end
+
+  describe "delete calculator" do
+    setup [:create_calculator]
+
+    test "deletes chosen calculator", %{conn: conn, calculator: calculator} do
+      conn = delete conn, calculator_path(conn, :delete, calculator)
+      assert response(conn, 204)
+      assert_error_sent 404, fn ->
+        get conn, calculator_path(conn, :show, calculator)
+      end
+    end
+  end
+
+  defp create_calculator(_) do
+    calculator = fixture(:calculator)
+    {:ok, calculator: calculator}
+  end
+end


### PR DESCRIPTION
As rotas ficaram:

- GET  /api/v1/sum/:num1/:num2
- GET  /api/v1/subtract/:num1/:num2
- GET  /api/v1/divide/:dividend/:divisor
- GET  /api/v1/multiply/:num1/:num2
